### PR TITLE
Bulk insert performance improvments

### DIFF
--- a/scripts/seed.py
+++ b/scripts/seed.py
@@ -167,8 +167,8 @@ def create_transport_network(session, cities):
 
     created_links = set()
     for _repeat in range(round(chain_count - 0.25)):  # biased rounding
-        random.shuffle(cities)
-        for city, neighbour in pairwise_full_circle(cities):
+        shuffled_cities = random.sample(cities, len(cities))
+        for city, neighbour in pairwise_full_circle(shuffled_cities):
             lower, higher = sorted((city, neighbour), key=lambda city: city.id)
             if (lower, higher) not in created_links:
                 created_links.add((lower, higher))

--- a/scripts/seed.py
+++ b/scripts/seed.py
@@ -122,15 +122,15 @@ def create_cities(session):
     """Creates cities for people to live in and companies to work at."""
     company_params = seed_json('business')
     company_params['names']['finalizer'] += company_params['names']['suffix']
-    make_company = CompanyGenerator(**company_params)
     make_city = city_generator(**seed_json('cities'))
+    make_company = CompanyGenerator(**company_params)
     names_and_sizes = map(split_field(';'), seed_entries('cities'))
     for city in itertools.starmap(make_city, names_and_sizes):
         size_args = itertools.repeat(city.size_code, city.seed_company_count)
-        city.companies.extend(map(make_company, size_args))
-        session.add(city)
-        session.flush()
+        city.companies = [make_company(size) for size in size_args]
         yield city
+        session.add(city)
+    session.flush()
 
 
 def create_transport_network(session, cities):

--- a/scripts/seed.py
+++ b/scripts/seed.py
@@ -41,6 +41,7 @@ class BulkSaver:
         self.mappings = mappings
         self.threshold = threshold
         self._objects = {mapping: [] for mapping in mappings}
+        self._mappings = {mapping: [] for mapping in mappings}
         self._pending = 0
 
     def __enter__(self):
@@ -50,20 +51,35 @@ class BulkSaver:
         if type is None:
             self.flush()
 
-    def add(self, obj):
+    def _increment_pending(self):
+        """Increments the 'pending' count and flushes when over threshold."""
+        self._pending += 1
+        if self._pending >= self.threshold:
+            self.flush()
+
+    def add_mapping(self, type_, mapping):
+        """Adds a type+mapping to the collection, or nothing when `None`.
+
+        Automatically flushes all pending objects when threshold is reached.
+        """
+        if mapping is not None:
+            self._mappings[type_].append(mapping)
+            self._increment_pending()
+
+    def add_object(self, obj):
         """Adds an object to the pending collection, or nothing when `None`.
 
         Automatically flushes all pending objects when threshold is reached.
         """
         if obj is not None:
             self._objects[type(obj)].append(obj)
-            self._pending += 1
-            if self._pending >= self.threshold:
-                self.flush()
+            self._increment_pending()
 
     def flush(self):
         """Bulk-saves objects to the database, in mapping order."""
         for mapping in self.mappings:
+            self.session.bulk_insert_mappings(mapping, self._mappings[mapping])
+            self._mappings[mapping] = []
             self.session.bulk_save_objects(self._objects.pop(mapping))
             self._objects[mapping] = []
         self._pending = 0
@@ -183,10 +199,11 @@ def create_population(session, cities):
     with BulkSaver(session, Person, Employment) as batch:
         for city in cities:
             for person in make_people(city.seed_population_size):
-                person.id = next(serial)
-                person.city_id = city.id
-                batch.add(person)
-                batch.add(employ_person(person, city.companies))
+                person['id'] = next(serial)
+                person['city_id'] = city.id
+                employment = employ_person(person, city.companies)
+                batch.add_mapping(Person, person)
+                batch.add_mapping(Employment, employment)
 
 
 def create_commuters(session, cities, closest_n=15):
@@ -208,7 +225,7 @@ def create_commuters(session, cities, closest_n=15):
                 neighbouring[city] = neighbours[1:closest_n + 1]
             companies = itertools.chain.from_iterable(
                 neighbour.companies for neighbour in neighbouring[city])
-            batch.add(employ_person(person, companies))
+            batch.add_mapping(Employment, employ_person(person, companies))
 
 
 def create_self_employment(session):
@@ -219,7 +236,7 @@ def create_self_employment(session):
                 city_salary = person.city.companies[0].seed_salary()
                 salary_multiplier = random.uniform(0.5, 1.2)
                 person.self_employment_income = city_salary * salary_multiplier
-                batch.add(person)
+                batch.add_object(person)
 
 
 def employ_person(person, companies):
@@ -233,13 +250,14 @@ def employ_person(person, companies):
             return {'role': 'manager', 'salary': max(salaries)}
         return {'role': 'director', 'salary': sum(salaries)}
 
+    person_id = person['id'] if isinstance(person, dict) else person.id
     for company in companies:
         if random.random() < company.seed_hiring_chance:
             company.seed_employee_count += 1
             company.seed_hiring_chance = math.pow(
                 company.seed_hiring_slowdown, -company.seed_employee_count)
-            return Employment(
-                person_id=person.id,
+            return dict(
+                person_id=person_id,
                 company_id=company.id,
                 **role_and_salary(company))
 

--- a/scripts/seed.py
+++ b/scripts/seed.py
@@ -241,14 +241,13 @@ def create_self_employment(session):
 
 def employ_person(person, companies):
     """Assign the person an employer from a list of companies."""
-    def role_and_salary(company):
-        percentile = random.uniform(0, 100)
-        if percentile < 85:
-            return {'role': 'worker', 'salary': company.seed_salary()}
-        salaries = company.seed_salary(), company.seed_salary()
-        if percentile < 98:
-            return {'role': 'manager', 'salary': max(salaries)}
-        return {'role': 'director', 'salary': sum(salaries)}
+    def role_and_salary(salary):
+        percentile = random.random()
+        if percentile < 0.85:
+            return {'role': 'worker', 'salary': salary()}
+        if percentile < 0.9:
+            return {'role': 'manager', 'salary': max(salary(), salary())}
+        return {'role': 'director', 'salary': salary() + salary()}
 
     person_id = person['id'] if isinstance(person, dict) else person.id
     for company in companies:
@@ -259,7 +258,7 @@ def employ_person(person, companies):
             return dict(
                 person_id=person_id,
                 company_id=company.id,
-                **role_and_salary(company))
+                **role_and_salary(company.seed_salary))
 
 
 def unemployed_people(session):

--- a/scripts/seed.py
+++ b/scripts/seed.py
@@ -80,7 +80,8 @@ def connect(db, user=None, echo=False):
     """
     if user is None:
         user = getpass.getuser()
-    return create_engine(f'postgres://{user}@/{db}', echo=echo)
+    return create_engine(
+        f'postgres://{user}@/{db}', echo=echo, use_batch_mode=True)
 
 
 def seed_entries(seed_file):

--- a/smallville/generators.py
+++ b/smallville/generators.py
@@ -7,8 +7,7 @@ import random
 
 from . models import (
     City,
-    Company,
-    Person)
+    Company)
 
 
 class CompanyGenerator:
@@ -85,11 +84,11 @@ class PopulationGenerator:
             last_name_pool = self.last_name_pool(size)
         for _step in range(size):
             gender = self.random_gender()
-            yield Person(
-                birthday=self.random_birthday(),
-                gender=gender,
-                first_name=random.choice(self._first_names[gender]),
-                last_name=pick_member(last_name_pool))
+            yield {
+                'birthday': self.random_birthday(),
+                'gender': gender,
+                'first_name': random.choice(self._first_names[gender]),
+                'last_name': pick_member(last_name_pool)}
 
     def last_name_pool(self, population_size, density_exponent=0.65):
         """Returns a pool of last names, based on population size.


### PR DESCRIPTION
A collection of major and minor performance improvements, in rough order of magnitude:

* Now inserts `Person` and `Employment` objects using `bulk_insert_mapping` which [removes overhead](https://docs.sqlalchemy.org/en/13/faq/performance.html#i-m-inserting-400-000-rows-with-the-orm-and-it-s-really-slow) of creating ORM objects, at slight cost to ease of use;
* Uses the [psycopg2 batch mode](https://docs.sqlalchemy.org/en/13/dialects/postgresql.html#psycopg2-batch-mode) for additional query performance;
* Small code reorganization and delayed flushing of `City` and `Company` objects.